### PR TITLE
Fixed error in order method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
 composer.lock
 vendor
+.idea

--- a/src/Resources/ResourceBase.php
+++ b/src/Resources/ResourceBase.php
@@ -147,7 +147,12 @@ abstract class ResourceBase {
      */
     function order($orderBy, $reverse = false)
     {
-        $this->requestDecorator->addParameter('order', ($reverse) ? "=" : "=-", $orderBy);
+        if ($reverse) {
+            $this->requestDecorator->addParameter('order', '=', '-' . $orderBy);
+        }
+        else {
+            $this->requestDecorator->addParameter('order', '=', $orderBy);
+        }
         return $this;
     }
 

--- a/tests/ResourceTests.php
+++ b/tests/ResourceTests.php
@@ -86,7 +86,7 @@ class ResourceTests extends PHPUnit_Framework_TestCase
             $this->assertArrayHasKey('skip', $query);
             $this->assertEquals(2, $query['skip']);
             $this->assertArrayHasKey('order', $query);
-            $this->assertEquals('cat', $query['order']);
+            $this->assertEquals('-cat', $query['order']);
             $this->assertCount(15, $query);
         }
 


### PR DESCRIPTION
While working with the SDK I found an error in the order method that caused a 400 Bad Request error with the Contentful API in the case that the $reverse parameter was false. This fixes that.
